### PR TITLE
remove git merge lines in utils.R

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,3 @@
-<<<<<<< HEAD
-=======
 #' Get vector of acceptable data types
 #'
 #' @examples
@@ -14,7 +12,6 @@ acceptable_types <- function() {
 
 }
 
->>>>>>> ba0dbd43cc9ec91e495143f253ac25a5b744607c
 #' Get lookup table of acceptable units for data (delta altered)
 #'
 #' @examples


### PR DESCRIPTION
Removes a left over git merge message from utils.R that was resulting in a non-zero exit status on install. Minimal testing on R version 4.5.2 on MacOS version 15.7.4 - consisting of installing this fork using R remotes package and loading the example raw data file - seems to fix the install issue. Fixes issue #25 